### PR TITLE
Halfway - use "aok" command instead of 1-install.sh

### DIFF
--- a/0-guide.txt
+++ b/0-guide.txt
@@ -11,26 +11,22 @@ Recommended:
 Developer Mode must be enabled already.
 
 1. Download Zip
-2. In Chrome OS, move the aok-master folder from the zip to Downloads
-3. CTRL+ALT+T for a crosh window, run "shell" for a shell
-4. as chronos, run "sudo cp -r ~/Downloads/aok-master/. /usr/local/aok"
-5. sudo su
-6. cd /usr/local/aok
-7. chmod +x *.sh
-8. ./1-install.sh
-9. Reboot. CTRL-U, Login (User: root, Pass: root), and follow directions (run 2 more scripts).
+2. Unzip by opening aok-master.zip and dragging aok-master to Downloads
+3. Press CTRL+ALT+T for a crosh window
+4. Type "shell" and press enter
+5. Type "sudo install -Dt /usr/local/bin ~/Downloads/aok-halfway/aok" and press enter
+6.
+7.
+8.
+9. Type "sudo aok" and press enter
 
-To run scripts after install:
-1. Login as "root", password "root"
-2. Type "./2-run-on-first-login.sh" and press enter to run the script.
-3. Get online by typing "wifi-menu" and pressing enter.
-     This will run a program that guides you to connecting to a Wi-Fi network.
-     If the Wi-Fi Hotspot has a Landing Page, see the WiFi Hotspot Help file in "extra".
-     Once the system is installed, Landing Pages will work automatically and a browser
-     will be installed so you can visit the Landing Page and get online.
-4. Repeat the process for the next script, using that script name
 
-You may want to customize script 2 with:
+When you get online for the first time using "wifi-menu"...
+If the Wi-Fi Hotspot has a Landing Page, see the WiFi Hotspot Help file in "extra".
+Once the system is installed, Landing Pages will work automatically.
+
+
+You may want to customize:
   - Your locale
   - Your own username
   - Your own hostname
@@ -52,9 +48,3 @@ assumes there is an issue and attempts to repair itself. I'm not exactly sure wh
 causes this, but again, it may erase everything within Chrome OS and start over.
 So it would be a good idea to back up any important files from Chrome OS, and
 generally not trusting Chrome OS to save any of your local files for you.
-
-I have also experienced an issue with gnome-packagekit, the gui package updater and
-package installer. After updating packages once, the Arch Linux system did not boot.
-Files should be recoverable by booting from Chrome OS and retrieving them, or by
-plugging the SD Card into a different system and retrieving them. But to avoid this
-issue, don't use gnome-packagekit, and always backup files before upgrading packages.

--- a/0-guide.txt
+++ b/0-guide.txt
@@ -11,10 +11,10 @@ Recommended:
 Developer Mode must be enabled already.
 
 1. Download Zip
-2. Unzip by opening aok-halfway.zip and dragging aok-halfway to Downloads
+2. Unzip by opening aok-master.zip and dragging aok-master to Downloads
 3. Press CTRL+ALT+T for a crosh window
 4. Type "shell" and press enter
-5. Type "sudo install -Dt /usr/local/bin ~/Downloads/aok-halfway/aok" and press enter
+5. Type "sudo install -Dt /usr/local/bin ~/Downloads/aok-master/aok" and press enter
 6.
 7.
 8.

--- a/0-guide.txt
+++ b/0-guide.txt
@@ -11,7 +11,7 @@ Recommended:
 Developer Mode must be enabled already.
 
 1. Download Zip
-2. Unzip by opening aok-master.zip and dragging aok-master to Downloads
+2. Unzip by opening aok-halfway.zip and dragging aok-halfway to Downloads
 3. Press CTRL+ALT+T for a crosh window
 4. Type "shell" and press enter
 5. Type "sudo install -Dt /usr/local/bin ~/Downloads/aok-halfway/aok" and press enter

--- a/aok
+++ b/aok
@@ -10,7 +10,7 @@ if [ "$EUID" != 0 ]; then
   exit 1
 fi
 ## Copy aok files
-cp -r ~/Downloads/aok-halfway/. /usr/local/aok
+cp -r /home/chronos/user/Downloads/aok-halfway/. /usr/local/aok
 cd /usr/local/aok
 ## Check for vboot-utils and more
 crossystem hwid && echo || echo "crossystem not found. OK."

--- a/aok
+++ b/aok
@@ -248,7 +248,7 @@ mkdir -p rootfs/etc/skel/.config/xfce4/panel/launcher-8
 cp files/15745773551.desktop \
     rootfs/etc/skel/.config/xfce4/panel/launcher-8
 ## Create a welcome message with instructions
-cat << EOF >> /etc/issue
+cat << EOF >> rootfs/etc/issue
 Welcome. To finish installing AOK, do the following:
 1. Login. The username is "root", and the default password is "root".
 2. Type "./2-run-on-first-login.sh" and press enter.

--- a/aok
+++ b/aok
@@ -9,6 +9,10 @@ if [ "$EUID" != 0 ]; then
   echo "Root privilege not found, quitting."
   exit 1
 fi
+## Copy aok files
+cp -r ~/Downloads/aok-halfway/. /usr/local/aok
+cd /usr/local/aok
+## Check for vboot-utils and more
 crossystem hwid && echo || echo "crossystem not found. OK."
 curl -V > /dev/null || { echo "curl not found. exiting."; exit 1; }
 ping -c 1 archlinuxarm.org > /dev/null \
@@ -25,30 +29,24 @@ echo "Tools check complete."
 ## Test mirrors and hopefully create bestmirrors.txt
 test_mirrors () {
 echo "Testing mirrors..."
-
 ## Create or reset the working mirrors list file, and set local mirror status
 echo -n > workingmirrors.txt.temp
 LOCAL_MIRROR_SUCCESS=false
-
 ## All local Arch Linux ARM mirrors, not the main load-balancing mirror
 ## This is the list from https://archlinuxarm.org/about/mirrors
 ## Plus the list provided in /etc/pacman.d/mirrorlist
 all_Mirrors=(au br2 dk de3 de de4 de5 de6 eu gr hu nl ru sg za tw ca.us nj.us fl.us il.us vn)
-
 ## Try to download md5 file for each mirror, recording speeds
 for SUBDOMAIN in ${all_Mirrors[@]}; do
-
   ## Download md5, and save Current Speed from curl progress meter
   ## A higher number is better. Domains that fail will have a null value.
   CURRENT_SPEED=`curl --max-time 5 -LO \
   ${SUBDOMAIN}.mirror.archlinuxarm.org/os/ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5 \
   2>&1 | grep $'\r100' | grep -o '[^ ]*$' || echo -n`
-
   ## What if it's a bad md5 file, like a 404?
   ## It should contain the filename, and be only 1 line
   if [ `grep ArchLinuxARM-armv7-chromebook-latest.tar.gz \
       ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5 | wc -l` -eq 1 ]; then
-
     ## Save the working mirror to a text file, Format: Speed (tab) Mirror
     if [ -n "$CURRENT_SPEED" ]; then
       echo -e "${CURRENT_SPEED}\t${SUBDOMAIN}.mirror.archlinuxarm.org" \
@@ -68,8 +66,6 @@ for SUBDOMAIN in ${all_Mirrors[@]}; do
         ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5 || echo -n
   fi
 done
-
-
 if [ "$LOCAL_MIRROR_SUCCESS" = true ]; then
   echo
   echo "These are your current best mirrors:"
@@ -81,14 +77,11 @@ else
   echo
   echo "No working local mirrors found."
 fi
-
 ## Cleanup
 rm -f ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5.temp
 rm -f workingmirrors.txt.temp
 echo "Mirrors testing complete."
 }
-
-
 
 ## Offline function, try using local md5 or quit
 use_local_md5 () {
@@ -104,7 +97,6 @@ install_arch () {
 echo "Preparing files..."
 mkdir -p distro
 cd distro
-
 ## Check if Internet and DNS is working before trying every mirror
 ## curl is built without metalink support in Chrome OS.
 ## it's a small file, so be impatient
@@ -125,12 +117,10 @@ else
     echo "Cannot download latest md5: archlinuxarm.org not found."
     use_local_md5
 fi
-
 ## Check even if it doesn't exist, or try downloading
 md5sum -c ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5 --status || {
   echo "Attempting download..."
   if ping -c 1 archlinuxarm.org > /dev/null; then
-  
     ## Here's where to use the fastest mirror from testing
     DOWNLOADED=false
     DL=1
@@ -164,11 +154,9 @@ md5sum -c ArchLinuxARM-armv7-chromebook-latest.tar.gz.md5 --status || {
 }
 cd -
 echo "File preparation complete."
-
 ## Now that everything is ready, truly get started
 echo "Starting Arch Linux Installation..."
 umount ${DEVICE}* || echo -n
-
 ## Do not change the whitespace here, it is important
 ## passing "y" in case it asks if sure. harmless if not asked.
 fdisk ${DEVICE} << END
@@ -187,14 +175,11 @@ n
 p
 w
 END
-
 ## Set special flags needed by U-Boot.
 ## or echo -n. Don't let so-called-cgpt-errors break the script
 cgpt add -i 1 -P 10 -T 5 -S 1 ${DEVICE} || echo -n
-
 ## Avoid mkfs complaining if it's 'apparently in use by the system' but isn't
 umount rootfs || echo -n
-
 ## Set up filesystem, copy files, and if on ChromeOS then enable booting
 mkfs.ext4 -F ${DEVICE}${PARTITION_2}
 mkdir -p rootfs
@@ -208,11 +193,9 @@ echo "Copying Boot Partition..."
 dd if=rootfs/boot/vmlinux.kpart of=${DEVICE}${PARTITION_1} status=progress
 echo "Boot Partition copy complete."
 crossystem dev_boot_usb=1 dev_boot_signed_only=0 || echo -n
-
 ## Don't let kernel messages garble the console; hide them instead.
 mkdir -p rootfs/etc/sysctl.d
 echo "kernel.printk = 3 3 3 3" >> rootfs/etc/sysctl.d/20-quiet-printk.conf
-
 ## Add best mirrors to pacman mirrorlist
 if [ -f distro/bestmirrors.txt ]; then
   ADD=1
@@ -227,14 +210,12 @@ if [ -f distro/bestmirrors.txt ]; then
     ADD=$[$ADD+1]
   done
 fi
-
 ## Bulk copy of custom content (will ALSO install in specific places)
 cp *.txt rootfs/root/
 install *.sh rootfs/root/
 cp -r files rootfs/root
 cp -r extra rootfs/root
 chmod +x rootfs/root/extra/*.sh
-
 ## ALSO, copy files to specific locations
 ## Copy quiet background for Xfce
 mkdir -p rootfs/usr/share/backgrounds/xfce
@@ -249,7 +230,6 @@ cp files/linux_archlinux_os_blue_black_logo_30861_1366x768.jpg rootfs/usr/share/
 ## Copy lightdm config
 mkdir -p rootfs/etc/lightdm
 cp files/lightdm-gtk-greeter.conf rootfs/etc/lightdm
-
 ## ALSO, Copy Global Xfce pre-configs
 ## Copy desktop, panel, power settings
 mkdir -p rootfs/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml
@@ -267,7 +247,6 @@ cp files/volumeicon \
 mkdir -p rootfs/etc/skel/.config/xfce4/panel/launcher-8
 cp files/15745773551.desktop \
     rootfs/etc/skel/.config/xfce4/panel/launcher-8
-
 ## Create a welcome message with instructions
 cat << EOF >> /etc/issue
 Welcome. To finish installing AOK, do the following:
@@ -277,7 +256,6 @@ Welcome. To finish installing AOK, do the following:
 4. Type "./3-run-when-online.sh" and press enter.
 
 EOF
-
 ## Finish up
 umount rootfs
 sync
@@ -326,7 +304,6 @@ echo "1) SD Card (/dev/mmcblk1)"
 echo "2) VirtualBox SD Card (/dev/sdb)"
 echo "q) Quit without making changes"
 echo
-
 read -p "> " CHOICE
 case "$CHOICE" in
   0)

--- a/aok
+++ b/aok
@@ -10,7 +10,7 @@ if [ "$EUID" != 0 ]; then
   exit 1
 fi
 ## Copy aok files
-cp -r /home/chronos/user/Downloads/aok-halfway/. /usr/local/aok
+cp -r /home/chronos/user/Downloads/aok-master/. /usr/local/aok
 cd /usr/local/aok
 ## Check for vboot-utils and more
 crossystem hwid && echo || echo "crossystem not found. OK."


### PR DESCRIPTION
master needed a fix: `rootfs/etc/issue` not `/etc/issue` so merging it all now.
branch testing has gone well, new process has been debugged, so merging to master

This merge is called "halfway" because it's half the way to being as easy as possible, using a script named "aok" instead of "1-install.sh" with a bunch of extra commands. it's actually much more than halfway easier, but as far as coding goes, it's halfway